### PR TITLE
Migrated from routes-router to http-hash-router and syntax cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,14 +5,14 @@
   "requires": true,
   "dependencies": {
     "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
+      "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.1.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "ap": {
@@ -25,7 +25,7 @@
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": "~2.1.0"
       }
     },
     "assert-plus": {
@@ -38,7 +38,7 @@
       "resolved": "https://registry.npmjs.org/async-cache/-/async-cache-1.1.0.tgz",
       "integrity": "sha1-SppaidBl7F2OUlS9nulrp2xTK1o=",
       "requires": {
-        "lru-cache": "4.1.3"
+        "lru-cache": "^4.0.0"
       }
     },
     "asynckit": {
@@ -60,18 +60,17 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "bl": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "requires": {
-        "readable-stream": "2.3.6",
-        "safe-buffer": "5.1.2"
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
       }
     },
     "body": {
@@ -79,7 +78,7 @@
       "resolved": "https://registry.npmjs.org/body/-/body-0.1.0.tgz",
       "integrity": "sha1-5xT+KM2ISKo0zfLJ8kK74uFdHNg=",
       "requires": {
-        "content-types": "0.1.0"
+        "content-types": "~0.1.0"
       }
     },
     "bootstrap": {
@@ -87,31 +86,36 @@
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.1.3.tgz",
       "integrity": "sha512-rDFIzgXcof0jDyjNosjv4Sno77X4KuPeFxG2XZZv1/Kc8DRVGVADdoQyyOVDwPqL36DDmtCQbrpMCqvpPLJQ0w=="
     },
+    "camelize": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
+      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
+    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    "cloud-env": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/cloud-env/-/cloud-env-0.2.3.tgz",
+      "integrity": "sha512-JdU/Wp4z0y8BfWR3w1dtKCo3H0zZje6s5kOTwH1lBYhUShS6SOQYYMnhNMWgWUbRC68BzAqZSFGi1hWaA383+g=="
     },
     "combined-stream": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "config-chain": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
-      "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
+      "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
       "requires": {
-        "ini": "1.3.5",
-        "proto-list": "1.2.4"
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
       }
     },
     "config-multipaas": {
@@ -119,15 +123,8 @@
       "resolved": "https://registry.npmjs.org/config-multipaas/-/config-multipaas-0.2.3.tgz",
       "integrity": "sha512-QCZAAj5M//s3O+vP7K0cX3RkiQxkMB8c3GnFcf5o5lr1ZZTAuPgxC64G1+3vqG/aRyXPL5OjVnPMsscDdSuGow==",
       "requires": {
-        "cloud-env": "0.2.3",
-        "config-chain": "1.1.11"
-      },
-      "dependencies": {
-        "cloud-env": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/cloud-env/-/cloud-env-0.2.3.tgz",
-          "integrity": "sha512-JdU/Wp4z0y8BfWR3w1dtKCo3H0zZje6s5kOTwH1lBYhUShS6SOQYYMnhNMWgWUbRC68BzAqZSFGi1hWaA383+g=="
-        }
+        "cloud-env": "^0.2.3",
+        "config-chain": "^1.1.11"
       }
     },
     "content-types": {
@@ -135,13 +132,8 @@
       "resolved": "https://registry.npmjs.org/content-types/-/content-types-0.1.0.tgz",
       "integrity": "sha1-DnkLOr/vkPbst3roWF25CZyvdXg=",
       "requires": {
-        "iterators": "0.1.0"
+        "iterators": "~0.1.0"
       }
-    },
-    "cookies": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.3.8.tgz",
-      "integrity": "sha1-kv5QkY89Va7Erp2Xi83doq2ijOk="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -153,7 +145,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "delayed-stream": {
@@ -161,23 +153,29 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
+    "dotenv": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.1.0.tgz",
+      "integrity": "sha512-/veDn2ztgRlB7gKmE3i9f6CmDIyXAy6d5nBq+whO9SLX+Zs1sXEgFLPi+aSuWqUuusMfbi84fT8j34fs1HaYUw=="
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "optional": true,
       "requires": {
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "error": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/error/-/error-3.0.0.tgz",
-      "integrity": "sha1-opV9z9AuZsztB8Eg0gtvv3+djXg=",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/error/-/error-5.2.0.tgz",
+      "integrity": "sha1-P7WdFnkAWEZkgfrhYBLmnkMvukI=",
       "requires": {
-        "string-template": "0.1.3",
-        "xtend": "2.1.2"
+        "camelize": "^1.0.0",
+        "is-error": "^2.0.0",
+        "string-template": "~0.2.0",
+        "xtend": "~4.0.0"
       }
     },
     "extend": {
@@ -191,9 +189,9 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -211,13 +209,13 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.6",
-        "mime-types": "2.1.19"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
       }
     },
     "getpass": {
@@ -225,23 +223,14 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "optional": true
-    },
-    "hammock": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/hammock/-/hammock-0.1.10.tgz",
-      "integrity": "sha1-6+Ss5uRySDGEgS0Sv5ccybbxS3w=",
-      "requires": {
-        "cookies": "0.3.8",
-        "lodash": "2.4.2"
-      }
     },
     "har-schema": {
       "version": "2.0.0",
@@ -249,12 +238,28 @@
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
-      "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.2.tgz",
+      "integrity": "sha512-OFxb5MZXCUMx43X7O8LK4FKggEQx6yC5QPmOcBnYbJ9UjxEcMcrMbaR0af5HZpqeFopw2GwQRQi34ZXI7YLM5w==",
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
+      }
+    },
+    "http-hash": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/http-hash/-/http-hash-1.1.1.tgz",
+      "integrity": "sha1-3yBnnR3zWQUqPIVyvzNSMHYtQo0="
+    },
+    "http-hash-router": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/http-hash-router/-/http-hash-router-1.1.0.tgz",
+      "integrity": "sha1-owMsdoRFRfflqYPBoe0XFVjNmvg=",
+      "requires": {
+        "error": "^5.0.0",
+        "http-hash": "^1.0.2",
+        "http-methods": "^1.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "http-methods": {
@@ -262,8 +267,8 @@
       "resolved": "https://registry.npmjs.org/http-methods/-/http-methods-1.1.0.tgz",
       "integrity": "sha1-3ixbYOVxEviZ/IXxJz731W2Xuxo=",
       "requires": {
-        "body": "0.1.0",
-        "content-types": "0.1.0"
+        "body": "~0.1.0",
+        "content-types": "~0.1.0"
       }
     },
     "http-signature": {
@@ -271,15 +276,10 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.2"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
-    },
-    "httperr": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/httperr/-/httperr-0.5.0.tgz",
-      "integrity": "sha1-/dfU7iLbCrXdtoziht6kADgRSFM="
     },
     "inherits": {
       "version": "2.0.3",
@@ -290,6 +290,11 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+    },
+    "is-error": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-error/-/is-error-2.2.1.tgz",
+      "integrity": "sha1-aEqW2EB2V3yY9M20DG0mpRI78Zw="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -311,7 +316,7 @@
       "resolved": "https://registry.npmjs.org/iterators/-/iterators-0.1.0.tgz",
       "integrity": "sha1-0D9mbKTmEwE4VlmXys6lQWQgMVY=",
       "requires": {
-        "ap": "0.1.0"
+        "ap": "~0.1.0"
       }
     },
     "jquery": {
@@ -322,8 +327,7 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "optional": true
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "json-schema": {
       "version": "0.2.3",
@@ -331,9 +335,9 @@
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -351,18 +355,13 @@
         "verror": "1.10.0"
       }
     },
-    "lodash": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-      "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
-    },
     "lru-cache": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
       "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "mime": {
@@ -371,16 +370,16 @@
       "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
     },
     "mime-db": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
-      "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg=="
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
     },
     "mime-types": {
-      "version": "2.1.19",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
-      "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
+      "version": "2.1.21",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+      "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
       "requires": {
-        "mime-db": "1.35.0"
+        "mime-db": "~1.37.0"
       }
     },
     "negotiator": {
@@ -393,11 +392,6 @@
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
-    "object-keys": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-      "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
-    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -405,7 +399,7 @@
     },
     "phaser": {
       "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/phaser/-/phaser-2.6.2.tgz",
+      "resolved": "http://registry.npmjs.org/phaser/-/phaser-2.6.2.tgz",
       "integrity": "sha1-6zkSFyWiFJxJ9GtdFEMYwivAkkk="
     },
     "popper.js": {
@@ -434,9 +428,9 @@
       "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
     },
     "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.5.2",
@@ -445,16 +439,16 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.2",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "request": {
@@ -462,64 +456,26 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.8.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.2",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.1.0",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.19",
-        "oauth-sign": "0.9.0",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.2",
-        "tough-cookie": "2.4.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.3.2"
-      }
-    },
-    "routes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/routes/-/routes-2.1.0.tgz",
-      "integrity": "sha1-R1VxGSpI+ZtsBl3ZJrt16K6D6KI="
-    },
-    "routes-router": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/routes-router/-/routes-router-4.3.0.tgz",
-      "integrity": "sha1-QDmwnU9AcgqAP6YtMX4h73r9TFQ=",
-      "requires": {
-        "error": "3.0.0",
-        "hammock": "0.1.10",
-        "http-methods": "1.1.0",
-        "httperr": "0.5.0",
-        "inherits": "2.0.3",
-        "routes": "2.1.0",
-        "send-data": "3.3.4",
-        "xtend": "2.1.2"
-      },
-      "dependencies": {
-        "send-data": {
-          "version": "3.3.4",
-          "resolved": "https://registry.npmjs.org/send-data/-/send-data-3.3.4.tgz",
-          "integrity": "sha1-70hJXJvJiLbf8PYkVQEXmxoQzNk=",
-          "requires": {
-            "json-stringify-safe": "5.0.1",
-            "xtend": "3.0.0"
-          },
-          "dependencies": {
-            "xtend": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-              "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
-            }
-          }
-        }
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
       }
     },
     "safe-buffer": {
@@ -537,31 +493,24 @@
       "resolved": "https://registry.npmjs.org/send-data/-/send-data-8.0.0.tgz",
       "integrity": "sha1-g5jswfuklTR1eowXpI+lg8qqruw=",
       "requires": {
-        "json-stringify-safe": "5.0.1",
-        "xtend": "4.0.1"
-      },
-      "dependencies": {
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-        }
+        "json-stringify-safe": "^5.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "sshpk": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
-      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
+      "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
       "requires": {
-        "asn1": "0.2.4",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.2",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.2",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       }
     },
     "st": {
@@ -569,25 +518,25 @@
       "resolved": "https://registry.npmjs.org/st/-/st-1.2.2.tgz",
       "integrity": "sha512-goKkumvz0BMLs6KjjPf5Fub/3T34tRVQxInUI5lqtbaKD+s4HcRlJYP2GPJ8RgAmrsnYOPGmOFEP6ho0KJ+E8g==",
       "requires": {
-        "async-cache": "1.1.0",
-        "bl": "1.2.2",
-        "fd": "0.0.3",
-        "graceful-fs": "4.1.11",
-        "mime": "1.4.1",
-        "negotiator": "0.6.1"
+        "async-cache": "~1.1.0",
+        "bl": "~1.2.1",
+        "fd": "~0.0.2",
+        "graceful-fs": "~4.1.11",
+        "mime": "~1.4.1",
+        "negotiator": "~0.6.1"
       }
     },
     "string-template": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.1.3.tgz",
-      "integrity": "sha1-tWjY6dZwlUZ7pal/MTgoW1dLV/E="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
+      "integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0="
     },
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.0"
       }
     },
     "tough-cookie": {
@@ -595,8 +544,15 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "requires": {
-        "psl": "1.1.29",
-        "punycode": "1.4.1"
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        }
       }
     },
     "tunnel-agent": {
@@ -604,14 +560,21 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "optional": true
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -628,18 +591,15 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "xtend": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-      "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-      "requires": {
-        "object-keys": "0.4.0"
-      }
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "yallist": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
   "homepage": "https://github.com/openshift-evangelists/Wild-West-Frontend.git#readme",
   "dependencies": {
     "bootstrap": "^4.1.3",
-    "dotenv": "^6.1.0",
     "config-multipaas": "^0.2.3",
+    "dotenv": "^6.1.0",
+    "http-hash-router": "^1.1.0",
     "jquery": "^3.3.1",
     "phaser": "^2.6.2",
     "popper.js": "^1.14.4",
     "request": "^2.88.0",
-    "routes-router": "^4.3.0",
     "send-data": "^8.0.0",
     "st": "^1.2.2"
   }

--- a/server.js
+++ b/server.js
@@ -1,14 +1,14 @@
-var config   = require('./bin/config.js'),
-    fs       = require('fs'),
-    http     = require("http"),
-    st       = require("st"),
-    request  = require('request'),
-    Router   = require("routes-router"),
-    sendJson = require("send-data/json"),
-    sendHtml = require("send-data/html"),
-    sendError= require("send-data/error")
+var config         = require('./bin/config.js'),
+    fs             = require('fs'),
+    http           = require('http'),
+    HttpHashRouter = require('http-hash-router'),
+    st             = require('st'),
+    request        = require('request'),
+    sendJson       = require('send-data/json'),
+    sendHtml       = require('send-data/html'),
+    sendError      = require('send-data/error')
 
-var app      = Router()
+var router = HttpHashRouter();
 
 var backend_path = config.get('backend_path'),
     frontend_path= config.get('frontend_path'),
@@ -25,8 +25,8 @@ var backend_proxy = function (req, res, opts, cb) {
 }
 var index_page = function (req, res, opts, cb) {
   var index_html = fs.readFileSync(__dirname + '/index.html');
-  if(backend_path !== "/ws"){
-    index_html = index_html.toString().replace("// BACKEND_PATH_CONFIG", "window.backend_path = \""+backend_path+"\";");
+  if(backend_path !== '/ws'){
+    index_html = index_html.toString().replace('// BACKEND_PATH_CONFIG', 'window.backend_path = \''+backend_path+'\';');
   }
   sendHtml(req, res, {
     body: index_html,
@@ -35,19 +35,19 @@ var index_page = function (req, res, opts, cb) {
 };
 
 // Routes
-app.addRoute( backend_path+"*", backend_proxy);
-app.addRoute( frontend_path, index_page);
+router.set(backend_path+'*', backend_proxy);
+router.set(frontend_path, index_page);
 
 // Ensure that we return *something* on the default path
-if( frontend_path !== "/"){
-  app.addRoute("/", function (req, res, opts, cb) {
+if( frontend_path !== '/'){
+  router.set('/', function (req, res, opts, cb) {
     sendHtml(req, res, {
       body: config.get('path_info'),
       statusCode: 200
     })
   });
   // append trailing slash - ensure a valid relative path for static assets
-  app.addRoute( config.get('no_slash_frontend'), function (req, res, opts, cb) {
+  router.set(config.get('no_slash_frontend'), function (req, res, opts, cb) {
     res.statusCode=302;
     res.setHeader('Location', frontend_path );
     res.end();
@@ -57,27 +57,36 @@ if( frontend_path !== "/"){
 // Serve static assets from our static_content folders
 var static_content=['assets','node_modules'];
 for(var folder in static_content){
-  app.addRoute( frontend_path+static_content[folder]+"/*", st({
+  router.set(frontend_path+static_content[folder]+"/*", st({
     path: static_content[folder], url: frontend_path+static_content[folder]
-  }))
+  }));
 }
 
 // TODO: these two functions are just for testing, can be deleted:
-app.addRoute( frontend_path+"status", function (req, res, opts, cb) {
+router.set(frontend_path+'status', function (req, res, opts, cb) {
   sendJson(req, res, {'status': 'ok'})
-})
-app.addRoute( frontend_path+"hostname", function (req, res, opts, cb) {
-  var data = "<p>Hostname: " + config.get('HOSTNAME') + "</p>";
+});
+
+router.set(frontend_path+'hostname', function (req, res, opts, cb) {
+  var data = '<p>Hostname: ' + config.get('HOSTNAME') + '</p>';
   sendHtml(req, res, {
     body: data,
     statusCode: 200
   })
-})
+});
 
 // Listen
-var server = http.createServer(app)
+var server = http.createServer(function handler(req, res) {
+  router(req, res, {}, onError);
+  function onError(err) {
+    if (err) {
+      res.statusCode = err.statusCode || 500;
+      res.end(err.message);
+    }
+  }
+});
 server.listen(config.get('PORT'), config.get('IP'), function () {
-  console.log( "Listening on " + config.get('IP') + ", port " + config.get('PORT') )
+  console.log( 'Listening on ' + config.get('IP') + ', port ' + config.get('PORT') )
   console.log( config.get('path_info') );
   if( !backend_host ){
     console.error(config.get('backend_config_error'));
@@ -85,3 +94,4 @@ server.listen(config.get('PORT'), config.get('IP'), function () {
     console.log(config.get('backend_config_info'));
   }
 });
+


### PR DESCRIPTION
Migrated from routes-router (deprecated) to http-hash-router to get rid of an npm audit vulnerability warning. Also changed everything to single quotes in server.js.